### PR TITLE
Make clojure-check friendly for acid.nvim

### DIFF
--- a/plugin/clojure-check.vim
+++ b/plugin/clojure-check.vim
@@ -19,8 +19,25 @@ function! s:ClojurePort()
   return fireplace#client().connection.transport.port
 endfunction
 
+function! s:ClojureHostPort()
+  if exists("g:acid_loaded")
+    let host_port = AcidGetUrl()
+  else
+    let host_port = [s:ClojureHost(), s:ClojurePort()]
+  endif
+  return join(host_port, ":")
+endfunction
+
+function! s:ClojureNs()
+  if exists("g:acid_loaded")
+    return AcidGetNs()
+  else
+    return fireplace#ns(a:buffer)
+  endif
+endfunction
+
 function! ClojureCheckArgs(buffer)
-  return ['-nrepl', s:ClojureHost().':'.s:ClojurePort(), '-namespace', fireplace#ns(a:buffer)]
+  return ['-nrepl', s:ClojureHostPort(), '-namespace', s:ClojureNs()]
 endfunction
 
 function! ClojureCheck(buffer)


### PR DESCRIPTION
This requires latest version of acid, which exposes Host and Port.

Cheers